### PR TITLE
Add test for sad path of DELETE projects

### DIFF
--- a/app.test.js
+++ b/app.test.js
@@ -223,7 +223,13 @@ describe('/api/v1', () => {
       const expectedMsg = `Project with the id: ${id} and it's palettes have been deleted.`;
       expect(response.status).toBe(200);
       expect(response.text).toBe(expectedMsg);
-    });
+    })
+    it('should return a 404 status and error message if project cant be found', async () => {
+      const id = 9999999
+      const response = await request(app).delete(`/api/v1/projects/${id}`)
+      expect(response.status).toBe(404)
+      expect(response.text).toEqual(`Project with the id:${id} was not found.`)
+    })
   })
 
   describe('DELETE /palettes/:id', () => {


### PR DESCRIPTION
### Description: 
#### Test sad paths for DELETE projects

#### Where should the reviewer start?
app.test.js

#### Covered by tests:
- [ X] Yes
- [ ] No

#### Impacted Areas of Application:
#### app.test.js

#### Todos before deployment:
- [ x]  Add query parameters in one of the endpoints
- [x ]  Test those 
- [ ] 

